### PR TITLE
Add dark theme dashboard and leaderboard

### DIFF
--- a/app/src/main/java/com/rumiznellasery/yogahelper/MainActivity.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/MainActivity.java
@@ -27,7 +27,10 @@ public class MainActivity extends AppCompatActivity {
         // Passing each menu ID as a set of Ids because each
         // menu should be considered as top level destinations.
         AppBarConfiguration appBarConfiguration = new AppBarConfiguration.Builder(
-                R.id.navigation_home, R.id.navigation_dashboard, R.id.navigation_workout)
+                R.id.navigation_home,
+                R.id.navigation_dashboard,
+                R.id.navigation_workout,
+                R.id.navigation_leaderboard)
                 .build();
         NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment_activity_main);
         NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);

--- a/app/src/main/java/com/rumiznellasery/yogahelper/ui/dashboard/DashboardFragment.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/ui/dashboard/DashboardFragment.java
@@ -4,6 +4,8 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.content.Context;
+import android.content.SharedPreferences;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
@@ -17,8 +19,17 @@ public class DashboardFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
         binding = FragmentDashboardBinding.inflate(inflater, container, false);
-
         View root = binding.getRoot();
+
+        SharedPreferences prefs = requireContext().getSharedPreferences("stats", Context.MODE_PRIVATE);
+        int workouts = prefs.getInt("workouts", 0);
+        int calories = prefs.getInt("calories", 0);
+        int streak = prefs.getInt("streak", 0);
+
+        binding.textTotalWorkouts.setText("Total workouts: " + workouts);
+        binding.textCalories.setText("Calories burned: " + calories);
+        binding.textStreak.setText("Streak: " + streak + " days");
+
         return root;
     }
 

--- a/app/src/main/java/com/rumiznellasery/yogahelper/ui/leaderboard/LeaderboardFragment.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/ui/leaderboard/LeaderboardFragment.java
@@ -1,0 +1,76 @@
+package com.rumiznellasery.yogahelper.ui.leaderboard;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+import com.rumiznellasery.yogahelper.databinding.FragmentLeaderboardBinding;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LeaderboardFragment extends Fragment {
+
+    private FragmentLeaderboardBinding binding;
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        binding = FragmentLeaderboardBinding.inflate(inflater, container, false);
+        View root = binding.getRoot();
+
+        List<String> names = new ArrayList<>();
+        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        if (user != null && user.getDisplayName() != null) {
+            names.add(user.getDisplayName());
+        } else {
+            names.add("You");
+        }
+        names.add("YogiBot");
+        names.add("StretchMaster");
+        names.add("ZenAI");
+        names.add("FlexBot");
+
+        String[] ranks = new String[]{
+                "Master Yogurt",
+                "Platinum Puller",
+                "Golden Gymnist",
+                "Silver Streacher",
+                "Bronze Beginner"
+        };
+
+        SharedPreferences prefs = requireContext().getSharedPreferences("stats", Context.MODE_PRIVATE);
+        int workouts = prefs.getInt("workouts", 0);
+
+        LinearLayout containerLayout = binding.containerRows;
+        containerLayout.removeAllViews();
+        for (int i = 0; i < names.size(); i++) {
+            TextView tv = new TextView(requireContext());
+            tv.setTextColor(getResources().getColor(android.R.color.white));
+            String text = (i + 1) + ". " + names.get(i) + " - " + ranks[i];
+            if (i == 0) {
+                text += " (" + workouts + " workouts)";
+            }
+            tv.setText(text);
+            tv.setTextSize(18);
+            tv.setPadding(0, 8, 0, 8);
+            containerLayout.addView(tv);
+        }
+        return root;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/app/src/main/java/com/rumiznellasery/yogahelper/ui/workout/WorkoutFragment.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/ui/workout/WorkoutFragment.java
@@ -1,6 +1,8 @@
 package com.rumiznellasery.yogahelper.ui.workout;
 
 import android.content.Intent;
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -25,6 +27,11 @@ public class WorkoutFragment extends Fragment {
         View root = binding.getRoot();
 
         View.OnClickListener listener = v -> {
+            SharedPreferences prefs = requireContext().getSharedPreferences("stats", Context.MODE_PRIVATE);
+            int workouts = prefs.getInt("workouts", 0) + 1;
+            int calories = prefs.getInt("calories", 0) + 50;
+            prefs.edit().putInt("workouts", workouts).putInt("calories", calories).putInt("streak", workouts).apply();
+
             Intent intent = new Intent(requireContext(), com.rumiznellasery.yogahelper.temp.TempActivity.class);
             startActivity(intent);
         };

--- a/app/src/main/res/drawable/ic_leaderboard_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_leaderboard_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,13h8L11,3L3,3v10zM3,21h8v-6L3,15v6zM13,21h8L21,11h-8v10zM13,3v6h8L21,3h-8z" />
+</vector>

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -5,13 +5,39 @@
     android:layout_height="match_parent"
     android:background="@drawable/background_gradient">
 
-    <TextView
-        android:id="@+id/text_dashboard"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/layout_stats"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="Dashboard"
+        android:orientation="vertical"
+        android:padding="32dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:id="@+id/text_total_workouts"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/white"
+            android:textSize="20sp"/>
+
+        <TextView
+            android:id="@+id/text_calories"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textColor="@color/white"
+            android:textSize="20sp"/>
+
+        <TextView
+            android:id="@+id/text_streak"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textColor="@color/white"
+            android:textSize="20sp"/>
+    </LinearLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_leaderboard.xml
+++ b/app/src/main/res/layout/fragment_leaderboard.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/background_gradient">
+
+    <LinearLayout
+        android:id="@+id/container_rows"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp" />
+</ScrollView>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -16,4 +16,9 @@
         android:icon="@drawable/ic_notifications_black_24dp"
         android:title="@string/title_workout" />
 
+    <item
+        android:id="@+id/navigation_leaderboard"
+        android:icon="@drawable/ic_leaderboard_black_24dp"
+        android:title="@string/title_leaderboard" />
+
 </menu>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -22,4 +22,10 @@
         android:name="com.rumiznellasery.yogahelper.ui.workout.WorkoutFragment"
         android:label="@string/title_workout"
         tools:layout="@layout/fragment_workout" />
+
+    <fragment
+        android:id="@+id/navigation_leaderboard"
+        android:name="com.rumiznellasery.yogahelper.ui.leaderboard.LeaderboardFragment"
+        android:label="@string/title_leaderboard"
+        tools:layout="@layout/fragment_leaderboard" />
 </navigation>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,6 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="gradient_start">#56ab2f</color>
-    <color name="gradient_end">#a8e063</color>
+    <color name="gradient_start">#000000</color>
+    <color name="gradient_end">#000000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="title_home">Account</string>
     <string name="title_dashboard">Dashboard</string>
     <string name="title_workout">Workout</string>
+    <string name="title_leaderboard">Leaderboard</string>
     <string name="sign_in">Sign In</string>
     <string name="sign_up">Sign Up</string>
     <string name="email_hint">Email</string>


### PR DESCRIPTION
## Summary
- make gradient background black
- show stats in Dashboard using `SharedPreferences`
- track workouts and calories from Workout page
- add new Leaderboard page with sample ranks
- wire leaderboard into navigation and menu

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621410241483229beb46ebe6d94a7d