### PR TITLE
Load Firebase leaderboard storage from config

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation libs.navigation.fragment
     implementation libs.navigation.ui
     implementation libs.firebase.auth
+    implementation libs.firebase.database
     testImplementation libs.junit
     androidTestImplementation libs.ext.junit
     androidTestImplementation libs.espresso.core

--- a/app/src/main/assets/db_keys.json
+++ b/app/src/main/assets/db_keys.json
@@ -1,0 +1,8 @@
+{
+  "database_url": "YOUR_DB_URL",
+  "users": "users",
+  "displayName": "displayName",
+  "workouts": "workouts",
+  "score": "score",
+  "level": "level"
+}

--- a/app/src/main/java/com/rumiznellasery/yogahelper/data/DbKeys.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/data/DbKeys.java
@@ -1,0 +1,47 @@
+package com.rumiznellasery.yogahelper.data;
+
+import android.content.Context;
+
+import org.json.JSONObject;
+import java.io.InputStream;
+
+/** Utility to load Firebase database keys from assets/db_keys.json. */
+public class DbKeys {
+    private static DbKeys instance;
+
+    public final String databaseUrl;
+    public final String users;
+    public final String displayName;
+    public final String workouts;
+    public final String score;
+    public final String level;
+
+    private DbKeys(Context context) {
+        String json;
+        try {
+            InputStream is = context.getAssets().open("db_keys.json");
+            int size = is.available();
+            byte[] buffer = new byte[size];
+            //noinspection ResultOfMethodCallIgnored
+            is.read(buffer);
+            is.close();
+            json = new String(buffer, java.nio.charset.StandardCharsets.UTF_8);
+            JSONObject obj = new JSONObject(json);
+            databaseUrl = obj.getString("database_url");
+            users = obj.getString("users");
+            displayName = obj.getString("displayName");
+            workouts = obj.getString("workouts");
+            score = obj.getString("score");
+            level = obj.getString("level");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load db keys", e);
+        }
+    }
+
+    public static synchronized DbKeys get(Context context) {
+        if (instance == null) {
+            instance = new DbKeys(context.getApplicationContext());
+        }
+        return instance;
+    }
+}

--- a/app/src/main/java/com/rumiznellasery/yogahelper/data/UserStats.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/data/UserStats.java
@@ -1,0 +1,17 @@
+package com.rumiznellasery.yogahelper.data;
+
+public class UserStats {
+    public String displayName;
+    public int workouts;
+    public int score;
+    public int level;
+
+    public UserStats() {}
+
+    public UserStats(String displayName, int workouts, int score, int level) {
+        this.displayName = displayName;
+        this.workouts = workouts;
+        this.score = score;
+        this.level = level;
+    }
+}

--- a/app/src/main/java/com/rumiznellasery/yogahelper/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/ui/home/HomeFragment.java
@@ -7,6 +7,9 @@ import android.view.ViewGroup;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.UserProfileChangeRequest;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.rumiznellasery.yogahelper.data.DbKeys;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
@@ -52,6 +55,10 @@ public class HomeFragment extends Fragment {
                     if (task.isSuccessful()) {
                         binding.textAccountDetails.setText(
                                 "Name: " + name + "\nEmail: " + currentUser.getEmail() + "\nUID: " + currentUser.getUid());
+                        DbKeys keys = DbKeys.get(requireContext());
+                        DatabaseReference ref = FirebaseDatabase.getInstance(keys.databaseUrl)
+                                .getReference(keys.users).child(currentUser.getUid());
+                        ref.child(keys.displayName).setValue(name);
                     }
                 });
             }

--- a/app/src/main/java/com/rumiznellasery/yogahelper/ui/workout/WorkoutFragment.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/ui/workout/WorkoutFragment.java
@@ -13,6 +13,12 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.rumiznellasery.yogahelper.databinding.FragmentWorkoutBinding;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ServerValue;
+import com.rumiznellasery.yogahelper.data.DbKeys;
 
 public class WorkoutFragment extends Fragment {
 
@@ -31,6 +37,15 @@ public class WorkoutFragment extends Fragment {
             int workouts = prefs.getInt("workouts", 0) + 1;
             int calories = prefs.getInt("calories", 0) + 50;
             prefs.edit().putInt("workouts", workouts).putInt("calories", calories).putInt("streak", workouts).apply();
+
+            FirebaseUser currentUser = FirebaseAuth.getInstance().getCurrentUser();
+            if (currentUser != null) {
+                DbKeys keys = DbKeys.get(requireContext());
+                DatabaseReference ref = FirebaseDatabase.getInstance(keys.databaseUrl)
+                        .getReference(keys.users).child(currentUser.getUid());
+                ref.child(keys.workouts).setValue(ServerValue.increment(1));
+                ref.child(keys.score).setValue(ServerValue.increment(1));
+            }
 
             Intent intent = new Intent(requireContext(), com.rumiznellasery.yogahelper.temp.TempActivity.class);
             startActivity(intent);

--- a/app/src/main/res/layout/activity_auth.xml
+++ b/app/src/main/res/layout/activity_auth.xml
@@ -31,6 +31,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/editTextEmail" />
 
+    <EditText
+        android:id="@+id/editTextDisplayName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:hint="@string/display_name_hint"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/editTextPassword" />
+
     <Button
         android:id="@+id/buttonSignIn"
         android:layout_width="0dp"
@@ -42,7 +52,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/editTextPassword" />
+        app:layout_constraintTop_toBottomOf="@+id/editTextDisplayName" />
 
     <Button
         android:id="@+id/buttonSignUp"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ navigationFragment = "2.6.0"
 navigationUi = "2.6.0"
 playServicesMaps = "19.2.0"
 firebaseAuth = "23.2.1"
+firebaseDatabase = "21.0.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -26,6 +27,7 @@ navigation-fragment = { group = "androidx.navigation", name = "navigation-fragme
 navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "navigationUi" }
 play-services-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "playServicesMaps" }
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth", version.ref = "firebaseAuth" }
+firebase-database = { group = "com.google.firebase", name = "firebase-database", version.ref = "firebaseDatabase" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add `db_keys.json` in the assets folder to store all Firebase Realtime Database keys
- introduce `DbKeys` helper to parse JSON and expose key values
- use `DbKeys` in all fragments and activities that access the database

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686313c0872c8322b3006a0045b15d28