### PR TITLE
Add workout tracking fields

### DIFF
--- a/app/src/main/assets/db_keys.json
+++ b/app/src/main/assets/db_keys.json
@@ -3,6 +3,9 @@
   "users": "users",
   "displayName": "displayName",
   "workouts": "workouts",
+  "totalWorkouts": "totalWorkouts",
+  "calories": "calories",
+  "streak": "streak",
   "score": "score",
   "level": "level"
 }

--- a/app/src/main/java/com/rumiznellasery/yogahelper/AuthActivity.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/AuthActivity.java
@@ -67,6 +67,9 @@ public class AuthActivity extends AppCompatActivity {
                                     String display = user.getDisplayName() == null ? "" : user.getDisplayName();
                                     ref.child(keys.displayName).setValue(display);
                                     ref.child(keys.workouts).setValue(0);
+                                    ref.child(keys.totalWorkouts).setValue(0);
+                                    ref.child(keys.calories).setValue(0);
+                                    ref.child(keys.streak).setValue(0);
                                     ref.child(keys.score).setValue(0);
                                     ref.child(keys.level).setValue(1);
                                 }
@@ -101,6 +104,9 @@ public class AuthActivity extends AppCompatActivity {
                                     .child(user.getUid());
                             ref.child(keys.displayName).setValue(name);
                             ref.child(keys.workouts).setValue(0);
+                            ref.child(keys.totalWorkouts).setValue(0);
+                            ref.child(keys.calories).setValue(0);
+                            ref.child(keys.streak).setValue(0);
                             ref.child(keys.score).setValue(0);
                             ref.child(keys.level).setValue(1);
                         }

--- a/app/src/main/java/com/rumiznellasery/yogahelper/data/DbKeys.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/data/DbKeys.java
@@ -13,6 +13,9 @@ public class DbKeys {
     public final String users;
     public final String displayName;
     public final String workouts;
+    public final String totalWorkouts;
+    public final String calories;
+    public final String streak;
     public final String score;
     public final String level;
 
@@ -31,6 +34,9 @@ public class DbKeys {
             users = obj.getString("users");
             displayName = obj.getString("displayName");
             workouts = obj.getString("workouts");
+            totalWorkouts = obj.optString("totalWorkouts", "totalWorkouts");
+            calories = obj.optString("calories", "calories");
+            streak = obj.optString("streak", "streak");
             score = obj.getString("score");
             level = obj.getString("level");
         } catch (Exception e) {

--- a/app/src/main/java/com/rumiznellasery/yogahelper/data/UserStats.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/data/UserStats.java
@@ -3,14 +3,20 @@ package com.rumiznellasery.yogahelper.data;
 public class UserStats {
     public String displayName;
     public int workouts;
+    public int totalWorkouts;
+    public int calories;
+    public int streak;
     public int score;
     public int level;
 
     public UserStats() {}
 
-    public UserStats(String displayName, int workouts, int score, int level) {
+    public UserStats(String displayName, int workouts, int totalWorkouts, int calories, int streak, int score, int level) {
         this.displayName = displayName;
         this.workouts = workouts;
+        this.totalWorkouts = totalWorkouts;
+        this.calories = calories;
+        this.streak = streak;
         this.score = score;
         this.level = level;
     }

--- a/app/src/main/java/com/rumiznellasery/yogahelper/ui/workout/WorkoutFragment.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/ui/workout/WorkoutFragment.java
@@ -44,6 +44,9 @@ public class WorkoutFragment extends Fragment {
                 DatabaseReference ref = FirebaseDatabase.getInstance(keys.databaseUrl)
                         .getReference(keys.users).child(currentUser.getUid());
                 ref.child(keys.workouts).setValue(ServerValue.increment(1));
+                ref.child(keys.totalWorkouts).setValue(ServerValue.increment(1));
+                ref.child(keys.calories).setValue(ServerValue.increment(50));
+                ref.child(keys.streak).setValue(ServerValue.increment(1));
                 ref.child(keys.score).setValue(ServerValue.increment(1));
             }
 


### PR DESCRIPTION
## Summary
- add more Firebase database key constants for tracking workouts and calories
- initialize new workout metrics when user signs up or logs in
- expose new workout metrics in the data model
- update workout fragment to increment new fields
- update db_keys.json with new paths

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686319aa65ac8322b7cb6159d8b2ec3e