### PR TITLE
Add workout icons and unify start actions

### DIFF
--- a/app/src/main/java/com/rumiznellasery/yogahelper/ui/workout/WorkoutFragment.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/ui/workout/WorkoutFragment.java
@@ -36,7 +36,7 @@ public class WorkoutFragment extends Fragment {
         binding = FragmentWorkoutBinding.inflate(inflater, container, false);
         View root = binding.getRoot();
 
-        View.OnClickListener updateStatsListener = v -> {
+        View.OnClickListener startWorkoutListener = v -> {
             SharedPreferences prefs = requireContext().getSharedPreferences("stats", Context.MODE_PRIVATE);
             int workouts = prefs.getInt("workouts", 0) + 1;
             int calories = prefs.getInt("calories", 0) + 50;
@@ -101,15 +101,9 @@ public class WorkoutFragment extends Fragment {
             startActivity(intent);
         };
 
-        View.OnClickListener cameraListener = v -> {
-            updateStatsListener.onClick(v);
-            Intent intent = new Intent(requireContext(), com.rumiznellasery.yogahelper.camera.CameraActivity.class);
-            startActivity(intent);
-        };
-
-        binding.buttonPlaceholder1.setOnClickListener(cameraListener);
-        binding.buttonPlaceholder2.setOnClickListener(updateStatsListener);
-        binding.buttonPlaceholder3.setOnClickListener(updateStatsListener);
+        binding.buttonPlaceholder1.setOnClickListener(startWorkoutListener);
+        binding.buttonPlaceholder2.setOnClickListener(startWorkoutListener);
+        binding.buttonPlaceholder3.setOnClickListener(startWorkoutListener);
         return root;
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,6 +13,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginBottom="4dp"
+        android:layout_marginTop="16dp"
         android:background="?android:attr/windowBackground"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHorizontal_bias="0.0"

--- a/app/src/main/res/layout/fragment_workout.xml
+++ b/app/src/main/res/layout/fragment_workout.xml
@@ -31,14 +31,26 @@
                     android:scaleType="centerCrop"
                     android:layout_marginBottom="8dp" />
 
-                <TextView
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/workout_name_1"
-                    android:textColor="@color/white"
-                    android:textSize="20sp"
-                    android:textStyle="bold"
-                    android:layout_marginBottom="8dp" />
+                    android:layout_marginBottom="8dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginEnd="8dp"
+                        android:src="@drawable/ic_dashboard_black_24dp" />
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/workout_name_1"
+                        android:textColor="@color/white"
+                        android:textSize="20sp"
+                        android:textStyle="bold" />
+                </LinearLayout>
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/button_placeholder1"
@@ -71,14 +83,26 @@
                     android:scaleType="centerCrop"
                     android:layout_marginBottom="8dp" />
 
-                <TextView
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/workout_name_2"
-                    android:textColor="@color/white"
-                    android:textSize="20sp"
-                    android:textStyle="bold"
-                    android:layout_marginBottom="8dp" />
+                    android:layout_marginBottom="8dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginEnd="8dp"
+                        android:src="@drawable/ic_account_circle_black_24dp" />
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/workout_name_2"
+                        android:textColor="@color/white"
+                        android:textSize="20sp"
+                        android:textStyle="bold" />
+                </LinearLayout>
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/button_placeholder2"
@@ -110,14 +134,26 @@
                     android:scaleType="centerCrop"
                     android:layout_marginBottom="8dp" />
 
-                <TextView
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/workout_name_3"
-                    android:textColor="@color/white"
-                    android:textSize="20sp"
-                    android:textStyle="bold"
-                    android:layout_marginBottom="8dp" />
+                    android:layout_marginBottom="8dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginEnd="8dp"
+                        android:src="@drawable/ic_home_black_24dp" />
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/workout_name_3"
+                        android:textColor="@color/white"
+                        android:textSize="20sp"
+                        android:textStyle="bold" />
+                </LinearLayout>
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/button_placeholder3"


### PR DESCRIPTION
## Summary
- show an icon next to each workout title
- send all workout buttons straight to the camera activity
- add top margin above the tab bar

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686391de3fb08322969945451e5c5660