### PR TITLE
Fix workout page layout

### DIFF
--- a/app/src/main/res/layout/fragment_workout.xml
+++ b/app/src/main/res/layout/fragment_workout.xml
@@ -5,7 +5,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/background_gradient">
+    android:background="@drawable/background_gradient"
+    android:paddingBottom="100dp">
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- add bottom padding to workout ScrollView so bottom navigation doesn't overlap content

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a35f826c83229d10221a4ddc2e41