### PR TITLE
Update leaderboard icon

### DIFF
--- a/app/src/main/res/drawable/ic_prize_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_prize_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M19,5h-2V3H7v2H5C3.9,5 3,5.9 3,7v1c0,2.55 1.92,4.63 4.39,4.94c0.63,1.5 1.98,2.63 3.61,2.96V19H7v2h10v-2h-4v-3.1c1.63,-0.33 2.98,-1.46 3.61,-2.96C19.08,12.63 21,10.55 21,8V7C21,5.9 20.1,5 19,5zM5,8V7h2v3.82C5.84,10.4 5,9.3 5,8zM19,8c0,1.3 -0.84,2.4 -2,2.82V7h2V8z"/>
+</vector>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -18,7 +18,7 @@
 
     <item
         android:id="@+id/navigation_leaderboard"
-        android:icon="@drawable/ic_leaderboard_black_24dp"
+        android:icon="@drawable/ic_prize_black_24dp"
         android:title="@string/title_leaderboard" />
 
 </menu>


### PR DESCRIPTION
## Summary
- add prize icon vector drawable
- update bottom navigation to use the prize icon for leaderboard

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a8bd0b608322a7b3d86d173ce82e