### PR TITLE
Fix missing LiteModuleLoader by adding Android lite dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,5 +61,6 @@ dependencies {
     implementation "androidx.camera:camera-view:$camerax_version"
 
     implementation libs.pytorch.android
+    implementation libs.pytorch.android.lite
     implementation libs.pytorch.android.torchvision
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ firebase-auth = { group = "com.google.firebase", name = "firebase-auth", version
 firebase-database = { group = "com.google.firebase", name = "firebase-database", version.ref = "firebaseDatabase" }
 pytorch-android = { group = "org.pytorch", name = "pytorch_android", version.ref = "pytorch" }
 pytorch-android-torchvision = { group = "org.pytorch", name = "pytorch_android_torchvision", version.ref = "pytorch" }
+pytorch-android-lite = { group = "org.pytorch", name = "pytorch_android_lite", version.ref = "pytorch" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- include PyTorch Lite module in dependency versions catalog
- use the new dependency in the Android app

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b86693b083229581473c82b9ccc0