### PR TITLE
Fix duplicate pytorch modules

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,7 +60,5 @@ dependencies {
     implementation "androidx.camera:camera-lifecycle:$camerax_version"
     implementation "androidx.camera:camera-view:$camerax_version"
 
-    implementation libs.pytorch.android
     implementation libs.pytorch.android.lite
-    implementation libs.pytorch.android.torchvision
 }


### PR DESCRIPTION
## Summary
- remove pytorch_android and torchvision dependencies to avoid class duplication

## Testing
- `./gradlew assembleDebug --warning-mode all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864bec199648322963b48408c7b4f03