### PR TITLE
Add preview of AI model input on workout start

### DIFF
--- a/app/src/main/java/com/rumiznellasery/yogahelper/camera/CameraActivity.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/camera/CameraActivity.java
@@ -3,6 +3,9 @@ package com.rumiznellasery.yogahelper.camera;
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.graphics.Bitmap;
+import android.media.Image;
+import android.widget.ImageView;
 
 import org.pytorch.Module;
 import org.pytorch.LiteModuleLoader;
@@ -11,6 +14,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.camera.core.CameraSelector;
 import androidx.camera.core.Preview;
+import androidx.camera.core.ImageAnalysis;
 import androidx.camera.lifecycle.ProcessCameraProvider;
 import androidx.camera.view.PreviewView;
 import androidx.core.app.ActivityCompat;
@@ -18,6 +22,7 @@ import androidx.core.content.ContextCompat;
 
 import com.rumiznellasery.yogahelper.R;
 import com.rumiznellasery.yogahelper.camera.AssetUtils;
+import com.rumiznellasery.yogahelper.camera.YuvToRgbConverter;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.concurrent.ExecutionException;
@@ -27,13 +32,19 @@ public class CameraActivity extends AppCompatActivity {
     private static final int REQUEST_CODE_PERMISSIONS = 10;
     private final String[] REQUIRED_PERMISSIONS = new String[]{Manifest.permission.CAMERA};
     private PreviewView previewView;
+    private ImageView modelView;
     private Module module;
+    private YuvToRgbConverter converter;
+    private Bitmap bitmapBuffer;
+    private static final int MODEL_INPUT_SIZE = 224;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_camera);
         previewView = findViewById(R.id.view_finder);
+        modelView = findViewById(R.id.model_input_view);
+        converter = new YuvToRgbConverter(this);
 
         try {
             module = LiteModuleLoader.load(AssetUtils.assetFilePath(this, "yolo11s-yoga.pt"));
@@ -67,8 +78,25 @@ public class CameraActivity extends AppCompatActivity {
                 CameraSelector cameraSelector = new CameraSelector.Builder()
                         .requireLensFacing(CameraSelector.LENS_FACING_FRONT)
                         .build();
+
+                ImageAnalysis analysis = new ImageAnalysis.Builder()
+                        .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                        .build();
+                analysis.setAnalyzer(ContextCompat.getMainExecutor(this), image -> {
+                    Image mediaImage = image.getImage();
+                    if (mediaImage != null) {
+                        if (bitmapBuffer == null) {
+                            bitmapBuffer = Bitmap.createBitmap(mediaImage.getWidth(), mediaImage.getHeight(), Bitmap.Config.ARGB_8888);
+                        }
+                        converter.yuvToRgb(mediaImage, bitmapBuffer);
+                        Bitmap scaled = Bitmap.createScaledBitmap(bitmapBuffer, MODEL_INPUT_SIZE, MODEL_INPUT_SIZE, true);
+                        runOnUiThread(() -> modelView.setImageBitmap(scaled));
+                    }
+                    image.close();
+                });
+
                 cameraProvider.unbindAll();
-                cameraProvider.bindToLifecycle(this, cameraSelector, preview);
+                cameraProvider.bindToLifecycle(this, cameraSelector, preview, analysis);
             } catch (ExecutionException | InterruptedException e) {
                 e.printStackTrace();
             }
@@ -84,6 +112,14 @@ public class CameraActivity extends AppCompatActivity {
             } else {
                 finish();
             }
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (converter != null) {
+            converter.release();
         }
     }
 }

--- a/app/src/main/java/com/rumiznellasery/yogahelper/camera/YuvToRgbConverter.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/camera/YuvToRgbConverter.java
@@ -1,0 +1,57 @@
+package com.rumiznellasery.yogahelper.camera;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.ImageFormat;
+import android.media.Image;
+import android.renderscript.Allocation;
+import android.renderscript.Element;
+import android.renderscript.RenderScript;
+import android.renderscript.ScriptIntrinsicYuvToRGB;
+
+import java.nio.ByteBuffer;
+
+public class YuvToRgbConverter {
+    private final RenderScript rs;
+    private final ScriptIntrinsicYuvToRGB script;
+    private Allocation in;
+    private Allocation out;
+
+    public YuvToRgbConverter(Context context) {
+        rs = RenderScript.create(context);
+        script = ScriptIntrinsicYuvToRGB.create(rs, Element.U8_4(rs));
+    }
+
+    public void yuvToRgb(Image image, Bitmap output) {
+        if (image.getFormat() != ImageFormat.YUV_420_888) return;
+        int width = image.getWidth();
+        int height = image.getHeight();
+        ByteBuffer yBuffer = image.getPlanes()[0].getBuffer();
+        ByteBuffer uBuffer = image.getPlanes()[1].getBuffer();
+        ByteBuffer vBuffer = image.getPlanes()[2].getBuffer();
+        int ySize = yBuffer.remaining();
+        int uSize = uBuffer.remaining();
+        int vSize = vBuffer.remaining();
+        byte[] nv21 = new byte[ySize + uSize + vSize];
+        yBuffer.get(nv21, 0, ySize);
+        vBuffer.get(nv21, ySize, vSize);
+        uBuffer.get(nv21, ySize + vSize, uSize);
+        if (in == null) {
+            in = Allocation.createSized(rs, Element.U8(rs), nv21.length);
+        }
+        if (out == null) {
+            out = Allocation.createFromBitmap(rs, output);
+        } else if (out.getType().getX() != width || out.getType().getY() != height) {
+            out.destroy();
+            out = Allocation.createFromBitmap(rs, output);
+        }
+        in.copyFrom(nv21);
+        script.setInput(in);
+        script.forEach(out);
+        out.copyTo(output);
+    }
+
+    public void release() {
+        rs.destroy();
+    }
+}

--- a/app/src/main/res/layout/activity_camera.xml
+++ b/app/src/main/res/layout/activity_camera.xml
@@ -16,6 +16,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <ImageView
+        android:id="@+id/model_input_view"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:layout_margin="16dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:background="@android:color/black" />
+
     <LinearLayout
         android:id="@+id/bottom_bar"
         android:layout_width="0dp"


### PR DESCRIPTION
## Summary
- add a YUV to RGB converter utility
- show processed camera frames in `CameraActivity`
- overlay small preview window on camera screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c04ace448322b4bb8b7d85839a3e