### PR TITLE
Fix camera crash on launch

### DIFF
--- a/app/src/main/java/com/rumiznellasery/yogahelper/camera/YuvToRgbConverter.java
+++ b/app/src/main/java/com/rumiznellasery/yogahelper/camera/YuvToRgbConverter.java
@@ -2,56 +2,27 @@ package com.rumiznellasery.yogahelper.camera;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.ImageFormat;
 import android.media.Image;
-import android.renderscript.Allocation;
-import android.renderscript.Element;
-import android.renderscript.RenderScript;
-import android.renderscript.ScriptIntrinsicYuvToRGB;
 
-import java.nio.ByteBuffer;
-
+/**
+ * Converts YUV camera frames to RGB Bitmaps.
+ *
+ * <p>This wrapper uses the AndroidX {@code YuvToRgbConverter} so that the
+ * application no longer depends on the platform RenderScript API, which was
+ * removed in newer Android versions.</p>
+ */
 public class YuvToRgbConverter {
-    private final RenderScript rs;
-    private final ScriptIntrinsicYuvToRGB script;
-    private Allocation in;
-    private Allocation out;
+    private final androidx.core.graphics.YuvToRgbConverter converter;
 
     public YuvToRgbConverter(Context context) {
-        rs = RenderScript.create(context);
-        script = ScriptIntrinsicYuvToRGB.create(rs, Element.U8_4(rs));
+        converter = new androidx.core.graphics.YuvToRgbConverter(context);
     }
 
     public void yuvToRgb(Image image, Bitmap output) {
-        if (image.getFormat() != ImageFormat.YUV_420_888) return;
-        int width = image.getWidth();
-        int height = image.getHeight();
-        ByteBuffer yBuffer = image.getPlanes()[0].getBuffer();
-        ByteBuffer uBuffer = image.getPlanes()[1].getBuffer();
-        ByteBuffer vBuffer = image.getPlanes()[2].getBuffer();
-        int ySize = yBuffer.remaining();
-        int uSize = uBuffer.remaining();
-        int vSize = vBuffer.remaining();
-        byte[] nv21 = new byte[ySize + uSize + vSize];
-        yBuffer.get(nv21, 0, ySize);
-        vBuffer.get(nv21, ySize, vSize);
-        uBuffer.get(nv21, ySize + vSize, uSize);
-        if (in == null) {
-            in = Allocation.createSized(rs, Element.U8(rs), nv21.length);
-        }
-        if (out == null) {
-            out = Allocation.createFromBitmap(rs, output);
-        } else if (out.getType().getX() != width || out.getType().getY() != height) {
-            out.destroy();
-            out = Allocation.createFromBitmap(rs, output);
-        }
-        in.copyFrom(nv21);
-        script.setInput(in);
-        script.forEach(out);
-        out.copyTo(output);
+        converter.yuvToRgb(image, output);
     }
 
     public void release() {
-        rs.destroy();
+        // no-op for AndroidX implementation
     }
 }


### PR DESCRIPTION
## Summary
- remove dependence on deprecated RenderScript API
- use AndroidX `YuvToRgbConverter` instead

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c2e8704c8322b530294da787ab6e