### PR TITLE
Fix missing YuvToRgbConverter class

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,7 @@ android {
 dependencies {
 
     implementation libs.appcompat
+    implementation libs.core
     implementation libs.material
     implementation libs.constraintlayout
     implementation libs.lifecycle.livedata.ktx

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ playServicesAuth = "21.3.0"
 firebaseAuth = "23.2.1"
 firebaseDatabase = "21.0.0"
 pytorch = "1.13.1"
+androidxCore = "1.13.1"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -34,6 +35,7 @@ firebase-database = { group = "com.google.firebase", name = "firebase-database",
 pytorch-android = { group = "org.pytorch", name = "pytorch_android", version.ref = "pytorch" }
 pytorch-android-torchvision = { group = "org.pytorch", name = "pytorch_android_torchvision", version.ref = "pytorch" }
 pytorch-android-lite = { group = "org.pytorch", name = "pytorch_android_lite", version.ref = "pytorch" }
+core = { group = "androidx.core", name = "core", version.ref = "androidxCore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add androidx core to version catalog
- use libs.core in app module

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c44b73308322891041dc14670708